### PR TITLE
Feature/remove object assign util

### DIFF
--- a/app/components/ImageGrid/ImageGrid.js
+++ b/app/components/ImageGrid/ImageGrid.js
@@ -70,9 +70,12 @@ function ImageGrid() {
     /* View functions */
     renderPhotoGrid: function (element, photos) {
       photos.forEach(function (props, index) {
-        var newProps = ObjectUtil.assign({}, props);
-        newProps.index = index;
-        newProps.className = 'grid-item';
+        var newProps = Object.keys(props).reduce(function (memo, key) {
+          memo[key] = props[key];
+
+          return memo;
+        }, {index: index, className: 'grid-item'});
+
         new Thumbnail().render(element, newProps);
       });
     },

--- a/app/components/ImageViewer/image-viewer.scss
+++ b/app/components/ImageViewer/image-viewer.scss
@@ -81,8 +81,9 @@
     cursor: pointer;
     display: inline-block;
     height: 50px;
-    right: 0;
     overflow: hidden;
+    right: 0;
+    top: 0;
     width: 50px;
 
     &:hover {

--- a/app/events/EventEmitter.js
+++ b/app/events/EventEmitter.js
@@ -34,7 +34,7 @@ function EventEmitter() {
 
     /**
      * Subscribe to change fired by implementing component
-     * @param  {function} hander handler that is called on change
+     * @param  {Function} hander handler that is called on change
      */
     on: function (eventName, handler) {
       if (!eventName) {
@@ -64,7 +64,7 @@ function EventEmitter() {
 
     /**
      * Unsubscribe from change events fired by implementing component
-     * @param  {function} handler to remove from change events
+     * @param  {Function} handler to remove from change events
      */
     removeListener: function (eventName, handler) {
       if (!subscriptions[eventName]) {

--- a/app/utils/FunctionUtil.js
+++ b/app/utils/FunctionUtil.js
@@ -3,9 +3,9 @@ var FunctionUtil = {
    * Returns a function, that, as long as it continues to be invoked, will not
    * be triggered. The function will be called after it stops being called for
    * N milliseconds. Triggers the function on the trailing edge.
-   * @param  {function} callback function to call
-   * @param  {integer} wait Miliseconds to wait for each call
-   * @return {function} a debounced function that will call callback
+   * @param  {Function} callback function to call
+   * @param  {Integer} wait Miliseconds to wait for each call
+   * @return {Function} a debounced function that will call callback
    * when invoked
    */
   debounce: function (callback, wait) {

--- a/app/utils/ObjectUtil.js
+++ b/app/utils/ObjectUtil.js
@@ -1,43 +1,19 @@
 var ObjectUtil = {
   /**
-   * Polyfill from MDN
-   * Copies values of all enumerable own properties from one or more source
-   * objects to a target object. It will return the target object.
-   * @param  {object} target the object to copy to
-   * @param  {object} source(s) the object to copy from
-   * @return {object} the object with source properties copied to target.
-   */
-  assign: function (target) { // , ...source
-    if (target == null) {
-      throw new TypeError('Cannot convert undefined or null to object');
-    }
-
-    target = Object(target);
-    for (var index = 1; index < arguments.length; index++) {
-      var source = arguments[index];
-      if (source != null) {
-        for (var key in source) {
-          if (Object.prototype.hasOwnProperty.call(source, key)) {
-            target[key] = source[key];
-          }
-        }
-      }
-    }
-
-    return target;
-  },
-
-  /**
    * Creates a new object with properties from ChildInstance and
    * adds ParentInstance as the prototype object.
-   * @param  {{object|function}} ChildInstance properties to have on
+   * @param  {{Object|Function}} ChildInstance properties to have on
    * newly created object
-   * @param  {{object|function}} ParentInstance prototype to have on
+   * @param  {{Object|Function}} ParentInstance prototype to have on
    * newly created object
-   * @return {object} the object with ChildInstance properties
+   * @param  {{Object}} propertiesObject Optional. An object whose enumerable
+   * own properties specify property descriptors to be added to the
+   * newly-created object
+   * @return {Object} the object with ChildInstance properties
    * and ParentInstance protoype.
    */
-  inherits: function (ChildInstance, ParentInstance) {
+  inherits: function (ChildInstance, ParentInstance, propertiesObject) {
+    propertiesObject || (propertiesObject = {});
     var parentInstance = ParentInstance;
     var childInstance = ChildInstance;
 
@@ -49,7 +25,18 @@ var ObjectUtil = {
       childInstance = new ChildInstance();
     }
 
-    return this.assign(Object.create(parentInstance), childInstance);
+    var properties = Object.keys(childInstance).reduce(function (memo, key) {
+      memo[key] = {
+        value: childInstance[key],
+        writable: propertiesObject.writable !== false, // default to true
+        enumerable: propertiesObject.enumerable !== false, // default to true
+        configurable: propertiesObject.configurable !== false // default to true
+      };
+
+      return memo;
+    }.bind(this), {});
+
+    return Object.create(parentInstance, properties);
   }
 };
 

--- a/app/utils/RequestUtil.js
+++ b/app/utils/RequestUtil.js
@@ -3,8 +3,8 @@ var RequestUtil = {
   /**
    * Makes a request by adding a script tag to the body element with the src
    * attribute as the request url
-   * @param  {string} url to request
-   * @param  {string} callbackName name of callback
+   * @param  {String} url to request
+   * @param  {String} callbackName name of callback
    * @param  {Function} callback to be called when request returns
    */
   jsonp: function (url, callbackName, callback) {

--- a/app/utils/__tests__/ObjectUtil-test.js
+++ b/app/utils/__tests__/ObjectUtil-test.js
@@ -5,29 +5,6 @@ var ObjectUtil = require('../ObjectUtil');
 
 describe('ObjectUtil', function () {
 
-  describe('#assign()', function () {
-
-    it('error cases', function () {
-      expect(function () { ObjectUtil.assign(null); }).to.throw();
-      expect(function () { ObjectUtil.assign(undefined); }).to.throw();
-      expect(function () { ObjectUtil.assign(null, {}); }).to.throw();
-      expect(function () { ObjectUtil.assign(undefined, {}); }).to.throw();
-    });
-
-    it('merges objects', function () {
-      expect(ObjectUtil.assign({a: 'a'}, {b: 'b'})).to.deep.equal({a: 'a', b: 'b'});
-    });
-
-    it('overrides propeties of target', function () {
-      expect(ObjectUtil.assign({a: 'a'}, {a: 'b'})).to.deep.equal({a: 'b'});
-    });
-
-    it('copies over undefined values', function () {
-      expect(ObjectUtil.assign({a: 'a'}, {a: undefined})).to.deep.equal({a: undefined});
-    });
-
-  });
-
   describe('#inherits()', function () {
 
     describe('objects', function () {
@@ -86,6 +63,56 @@ describe('ObjectUtil', function () {
         var b = function () { return {b: 'b', shared: 'b\'s shared'}; };
         expect(ObjectUtil.inherits(a, b).shared).to.equal('a\'s shared');
         expect(ObjectUtil.inherits(a, b).__proto__.shared).to.equal('b\'s shared');
+      });
+
+    });
+
+    describe('propertiesObject', function () {
+
+      it('defaults to writable true', function () {
+        var a = {a: 'a'};
+        var b = {b: 'b'};
+        var result = ObjectUtil.inherits(a, b);
+        result.a = 'c';
+        expect(result.a).to.equal('c');
+      });
+
+      it('passed propertiesObject overrides writable', function () {
+        var a = {a: 'a'};
+        var b = {b: 'b'};
+        var result = ObjectUtil.inherits(a, b, {writable: false});
+        result.a = 'c';
+        expect(result.a).to.equal('a');
+      });
+
+      it('defaults to enumerable true', function () {
+        var a = {a: 'a'};
+        var b = {b: 'b'};
+        var result = ObjectUtil.inherits(a, b);
+        expect(result.propertyIsEnumerable('a')).to.equal(true);
+      });
+
+      it('passed propertiesObject overrides enumerable', function () {
+        var a = {a: 'a'};
+        var b = {b: 'b'};
+        var result = ObjectUtil.inherits(a, b, {enumerable: false});
+        expect(result.propertyIsEnumerable('a')).to.equal(false);
+      });
+
+      it('defaults to configurable true', function () {
+        var a = {a: 'a'};
+        var b = {b: 'b'};
+        var result = ObjectUtil.inherits(a, b);
+        delete result.a;
+        expect(Object.prototype.hasOwnProperty.call(result, 'a')).to.equal(false);
+      });
+
+      it('passed propertiesObject overrides configurable', function () {
+        var a = {a: 'a'};
+        var b = {b: 'b'};
+        var result = ObjectUtil.inherits(a, b, {configurable: false});
+        delete result.a;
+        expect(Object.prototype.hasOwnProperty.call(result, 'a')).to.equal(true);
       });
 
     });


### PR DESCRIPTION
This PR removes the need of the ObjectUtil.assign function and replaces it with workarounds.