### PR TITLE
Bug fix: Reloading image viewer not working properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ module.exports = function MyComponent() {
       // Do something with element after mount
     },
 
+    componentDidUpdate() {
+      // Do something on component update
+    },
+
     componentWillUnmount() {
       // Clean up component
     },

--- a/app/components/Component/Component.js
+++ b/app/components/Component/Component.js
@@ -12,6 +12,10 @@
  *       // Do something with element after mount
  *     },
  *
+ *     componentDidUpdate() {
+ *       // Do something on component update
+ *     },
+ *
  *     componentWillUnmount() {
  *       // Clean up component
  *     },
@@ -37,6 +41,7 @@ function Component() {
     /**
      * Function to call when component should render into parent node
      * Calls componentDidMount when node has mounted
+     * Calls componentDidUpdate when node was updated
      * @param  {DOM Node} parentElement to render component within
      */
     render: function (parentElement) { // , ...props
@@ -68,13 +73,20 @@ function Component() {
         parentElement.appendChild(newElement);
       }
 
-      // Store our new instance
-      element = newElement;
-
-      if (typeof this.componentDidMount === 'function') {
-        var args = [element].concat(props);
+      // Call did mount
+      if (!element && typeof this.componentDidMount === 'function') {
+        var args = [newElement].concat(props);
         this.componentDidMount.apply(this, args);
       }
+
+      // Call did update
+      if (element && typeof this.componentDidUpdate === 'function') {
+        var args = [newElement].concat(props);
+        this.componentDidUpdate.apply(this, args);
+      }
+
+      // Store our new instance
+      element = newElement;
     },
 
     /**

--- a/app/components/Component/__tests__/Component-test.js
+++ b/app/components/Component/__tests__/Component-test.js
@@ -13,6 +13,7 @@ describe('Component', function () {
   beforeEach(function () {
     component = ObjectUtil.inherits({
       componentDidMount: sinon.spy(),
+      componentDidUpdate: sinon.spy(),
       componentWillUnmount: sinon.spy(),
       getView: function () {
         return '<div class="component">My Component</div>'
@@ -89,6 +90,18 @@ describe('Component', function () {
       expect(component.componentDidMount.getCall(0).args[1]).to.equal('one')
       expect(component.componentDidMount.getCall(0).args[2]).to.equal('two')
       expect(component.componentDidMount.getCall(0).args[3]).to.equal('three')
+    });
+
+    it('calls componentDidUpdate if implemented', function () {
+      component.render(div);
+      expect(component.componentDidUpdate.calledOnce).to.equal(true);
+    });
+
+    it('passes through arguments to componentDidUpdate', function () {
+      component.render(div, 'one', 'two', 'three');
+      expect(component.componentDidUpdate.getCall(0).args[1]).to.equal('one')
+      expect(component.componentDidUpdate.getCall(0).args[2]).to.equal('two')
+      expect(component.componentDidUpdate.getCall(0).args[3]).to.equal('three')
     });
 
   });

--- a/app/components/Component/__tests__/Component-test.js
+++ b/app/components/Component/__tests__/Component-test.js
@@ -77,10 +77,18 @@ describe('Component', function () {
     });
 
     it('passes through arguments to componentDidMount', function () {
+      component = ObjectUtil.inherits({
+        componentDidMount: sinon.spy(),
+        componentDidUpdate: sinon.spy(),
+        componentWillUnmount: sinon.spy(),
+        getView: function () {
+          return '<div class="component">My Component</div>'
+        }
+      }, Component);
       component.render(div, 'one', 'two', 'three');
-      expect(component.componentDidMount.getCall(1).args[1]).to.equal('one')
-      expect(component.componentDidMount.getCall(1).args[2]).to.equal('two')
-      expect(component.componentDidMount.getCall(1).args[3]).to.equal('three')
+      expect(component.componentDidMount.getCall(0).args[1]).to.equal('one')
+      expect(component.componentDidMount.getCall(0).args[2]).to.equal('two')
+      expect(component.componentDidMount.getCall(0).args[3]).to.equal('three')
     });
 
   });

--- a/app/components/ImageGrid/ImageGrid.js
+++ b/app/components/ImageGrid/ImageGrid.js
@@ -14,6 +14,10 @@ function ImageGrid() {
   return ObjectUtil.inherits({
     /* Lifecycle methods */
     componentDidMount: function (element) {
+      this.componentDidUpdate(element);
+    },
+
+    componentDidUpdate: function (element) {
       element.onclick = this.handleImageClick.bind(this, element.querySelector('.selected-image'));
       var photos = PhotoStore.getPhotos();
       this.renderPhotoGrid(element.querySelector('.grid'), photos);

--- a/app/components/ImageViewer/image-viewer.scss
+++ b/app/components/ImageViewer/image-viewer.scss
@@ -82,6 +82,7 @@
     display: inline-block;
     height: 50px;
     right: 0;
+    top: 0;
     overflow: hidden;
     width: 50px;
 

--- a/app/events/EventEmitter.js
+++ b/app/events/EventEmitter.js
@@ -34,7 +34,7 @@ function EventEmitter() {
 
     /**
      * Subscribe to change fired by implementing component
-     * @param  {function} hander handler that is called on change
+     * @param  {Function} hander handler that is called on change
      */
     on: function (eventName, handler) {
       if (!eventName) {
@@ -64,7 +64,7 @@ function EventEmitter() {
 
     /**
      * Unsubscribe from change events fired by implementing component
-     * @param  {function} handler to remove from change events
+     * @param  {Function} handler to remove from change events
      */
     removeListener: function (eventName, handler) {
       if (!subscriptions[eventName]) {

--- a/app/utils/FunctionUtil.js
+++ b/app/utils/FunctionUtil.js
@@ -3,9 +3,9 @@ var FunctionUtil = {
    * Returns a function, that, as long as it continues to be invoked, will not
    * be triggered. The function will be called after it stops being called for
    * N milliseconds. Triggers the function on the trailing edge.
-   * @param  {function} callback function to call
-   * @param  {integer} wait Miliseconds to wait for each call
-   * @return {function} a debounced function that will call callback
+   * @param  {Function} callback function to call
+   * @param  {Integer} wait Miliseconds to wait for each call
+   * @return {Function} a debounced function that will call callback
    * when invoked
    */
   debounce: function (callback, wait) {

--- a/app/utils/ObjectUtil.js
+++ b/app/utils/ObjectUtil.js
@@ -3,9 +3,9 @@ var ObjectUtil = {
    * Polyfill from MDN
    * Copies values of all enumerable own properties from one or more source
    * objects to a target object. It will return the target object.
-   * @param  {object} target the object to copy to
-   * @param  {object} source(s) the object to copy from
-   * @return {object} the object with source properties copied to target.
+   * @param  {Object} target the object to copy to
+   * @param  {Object} source(s) the object to copy from
+   * @return {Object} the object with source properties copied to target.
    */
   assign: function (target) { // , ...source
     if (target == null) {

--- a/app/utils/RequestUtil.js
+++ b/app/utils/RequestUtil.js
@@ -3,8 +3,8 @@ var RequestUtil = {
   /**
    * Makes a request by adding a script tag to the body element with the src
    * attribute as the request url
-   * @param  {string} url to request
-   * @param  {string} callbackName name of callback
+   * @param  {String} url to request
+   * @param  {String} callbackName name of callback
    * @param  {Function} callback to be called when request returns
    */
   jsonp: function (url, callbackName, callback) {


### PR DESCRIPTION
New event listeners was being added on componentDidMount (since that was also called on update) and not removed.

Introducing componentDidUpdate to handle these situations better, so components can add event listeners in did mount and only run update code in did update.

This also took care of a lot of unnecessary re-renders which makes applications using Component.js more performant.